### PR TITLE
fix leaflet build by calling jake via "npm run build"

### DIFF
--- a/aux/browserify-dependencies.sh
+++ b/aux/browserify-dependencies.sh
@@ -20,7 +20,7 @@ cd -
 
 cd node_modules/leaflet/
 npm install
-jake build
+npm run build
 cd -
 
 mkdir -p vendor


### PR DESCRIPTION
I don't have jake in PATH and browserify-dependencies.sh installs jake in node_modules/leaflet/.bin/jake so I think it's better to run it via "npm run build" which sets PATH accordingly.