### PR TITLE
allow to accept layer bbox as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ var url = 'https://{s}.tiles.mapbox.com/v4/mapbox.mapbox-streets-v6/{z}/{x}/{y}.
 var layer = L.vectorGrid.protobuf(url, options);
 ```
 
+`L.VectorGrid.Protobuf` can accept a `L.latLngBounds` option `bbox`, which defines the boundary box of the layer. If the `bbox` is specified, it won't send tile request to the server for the area outside the boundary box.
+
 ### Styling
 
 Vector tiles have a concept of "layer" different from the Leaflet concept of "layer".
@@ -183,4 +185,3 @@ can do whatever you want with this stuff. If we meet some day, and you think
 this stuff is worth it, you can buy me a beer in return.
 
 ----------------------------------------------------------------------------
-

--- a/src/Leaflet.VectorGrid.Protobuf.js
+++ b/src/Leaflet.VectorGrid.Protobuf.js
@@ -21,53 +21,53 @@ L.VectorGrid.Protobuf = L.VectorGrid.extend({
 
 	_getVectorTilePromise: function(coords) {
 
-    var promise;
+		var promise;
 
-    if (this.options.bbox) {
-      var bboxCoords = this._merc.bbox(coords.x, coords.y, coords.z);
-      var tileBbox = L.latLngBounds(L.latLng(bboxCoords[1], bboxCoords[0]), L.latLng(bboxCoords[3], bboxCoords[2]));
+		if (this.options.bbox) {
+			var bboxCoords = this._merc.bbox(coords.x, coords.y, coords.z);
+			var tileBbox = L.latLngBounds(L.latLng(bboxCoords[1], bboxCoords[0]), L.latLng(bboxCoords[3], bboxCoords[2]));
 
-      if (!this.options.bbox.overlaps(tileBbox)) {
-        promise = Promise.resolve({ layers:[] });
-      }
-    }
+			if (!this.options.bbox.overlaps(tileBbox)) {
+				promise = Promise.resolve({ layers:[] });
+			}
+		}
 
-    if (!promise) {
-      var tileUrl = L.Util.template(this._url, L.extend({
-  			s: this._getSubdomain(coords),
-  			x: coords.x,
-  			y: coords.y,
-  			z: coords.z
-  // 			z: this._getZoomForUrl()	/// TODO: Maybe replicate TileLayer's maxNativeZoom
-  		}, this.options));
+		if (!promise) {
+			var tileUrl = L.Util.template(this._url, L.extend({
+				s: this._getSubdomain(coords),
+				x: coords.x,
+				y: coords.y,
+				z: coords.z
+	// 			z: this._getZoomForUrl()	/// TODO: Maybe replicate TileLayer's maxNativeZoom
+			}, this.options));
 
-  		promise = fetch(tileUrl).then(function(response){
+			promise = fetch(tileUrl).then(function(response){
 
-  			if (!response.ok) {
-  				return {layers:[]};
-  			}
+				if (!response.ok) {
+					return {layers:[]};
+				}
 
-  			return response.blob().then( function (blob) {
-  // 				console.log(blob);
+				return response.blob().then( function (blob) {
+	// 				console.log(blob);
 
-  				var reader = new FileReader();
-  				return new Promise(function(resolve){
-  					reader.addEventListener("loadend", function() {
-  						// reader.result contains the contents of blob as a typed array
+					var reader = new FileReader();
+					return new Promise(function(resolve){
+						reader.addEventListener("loadend", function() {
+							// reader.result contains the contents of blob as a typed array
 
-  						// blob.type === 'application/x-protobuf'
-  						var pbf = new Pbf( reader.result );
-  // 						console.log(pbf);
-  						return resolve(new vectorTile.VectorTile( pbf ));
+							// blob.type === 'application/x-protobuf'
+							var pbf = new Pbf( reader.result );
+	// 						console.log(pbf);
+							return resolve(new vectorTile.VectorTile( pbf ));
 
-  					});
-  					reader.readAsArrayBuffer(blob);
-  				});
-  			});
-  		})
-    }
+						});
+						reader.readAsArrayBuffer(blob);
+					});
+				});
+			})
+		}
 
-    return promise.then(function(json){
+		return promise.then(function(json){
 
 // 			console.log('Vector tile:', json.layers);
 // 			console.log('Vector tile water:', json.layers.water);	// Instance of VectorTileLayer


### PR DESCRIPTION
This PR will allow `L.VectorGrid.Protobuf` to accept `bbox` as an option. It's a `L.latLngBounds` object that defines the boundary box of the layer. If it's specified, the `_getVectorTilePromise()` function will first check if the requested area is outside the layer boundary bbox and not send the request if so. This is useful for people, especially who use dynamically generated vector tile, to reduce the unnecessary calculation.